### PR TITLE
Split enable/disable rules

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -6,16 +6,31 @@ type Config struct {
 }
 
 type Feature struct {
-	Rules []Rule `yaml:"rules"`
+	Rules Rules `yaml:"rules"`
 }
 
-type Rule struct {
+type Rules struct {
+	Enable  []EnableRule  `yaml:"enable"`
+	Disable []DisableRule `yaml:"disable"`
+}
+
+type EnableRule struct {
 	Field  string   `yaml:"field"`
 	Fields []string `yaml:"fields"`
 
-	Include []string `yaml:"include"`
-	Exclude []string `yaml:"exclude"`
-	Weight  int      `yaml:"weight"`
+	Values MatchValues `yaml:"values"`
+	Weight int         `yaml:"weight"`
+}
+
+type DisableRule struct {
+	Field  string   `yaml:"field"`
+	Fields []string `yaml:"fields"`
+
+	Values MatchValues `yaml:"values"`
+}
+
+type MatchValues struct {
+	Eq []string `json:"eq"`
 }
 
 func (c *Config) Append(a Config) {
@@ -27,7 +42,8 @@ func (c *Config) Append(a Config) {
 	}
 	for name, feature := range a.Features {
 		if f, ok := c.Features[name]; ok {
-			f.Rules = append(f.Rules, a.Features[name].Rules...)
+			f.Rules.Enable = append(f.Rules.Enable, a.Features[name].Rules.Enable...)
+			f.Rules.Disable = append(f.Rules.Disable, a.Features[name].Rules.Disable...)
 			c.Features[name] = f
 		} else {
 			c.Features[name] = feature

--- a/cfg/fixtures/dir/profile.yml
+++ b/cfg/fixtures/dir/profile.yml
@@ -4,8 +4,9 @@ features:
 
   profile_page_v2:
     rules:
-      - fields:
-          - "email"
-          - "customer_id"
-        weight: 10
+      enable:
+        - fields:
+            - "email"
+            - "customer_id"
+          weight: 10
 

--- a/cfg/fixtures/dir/stripe.yaml
+++ b/cfg/fixtures/dir/stripe.yaml
@@ -4,12 +4,17 @@ features:
 
   stripe_billing:
     rules:
-      - field: "customer_id"
-        weight: 50
-        include:
-          - "123"
-          - "456"
-        exclude:
-          - "234"
-          - "567"
+      enable:
+        - field: "customer_id"
+          weight: 50
+          values:
+            eq:
+              - "123"
+              - "456"
+      disable:
+        - field: "customer_id"
+          values:
+            eq:
+              - "234"
+              - "567"
 

--- a/cfg/fixtures/dir/stripe2.yml
+++ b/cfg/fixtures/dir/stripe2.yml
@@ -4,9 +4,14 @@ features:
 
   stripe_billing:
     rules:
-      - field: "customer_id"
-        include:
-          - "111"
-        exclude:
-          - "222"
+      enable:
+        - field: "customer_id"
+          values:
+            eq:
+              - "111"
+      disable:
+        - field: "customer_id"
+          values:
+            eq:
+              - "222"
 

--- a/cfg/load_test.go
+++ b/cfg/load_test.go
@@ -15,25 +15,37 @@ var _ = Describe("cfg", func() {
 				Version: "1.0",
 				Features: map[string]Feature{
 					"profile_page_v2": {
-						Rules: []Rule{
-							{
-								Fields: []string{"email", "customer_id"},
-								Weight: 10,
+						Rules: Rules{
+							Enable: []EnableRule{
+								{
+									Fields: []string{"email", "customer_id"},
+									Weight: 10,
+								},
 							},
 						},
 					},
 					"stripe_billing": {
-						Rules: []Rule{
-							{
-								Field:   "customer_id",
-								Include: []string{"123", "456"},
-								Exclude: []string{"234", "567"},
-								Weight:  50,
+						Rules: Rules{
+							Enable: []EnableRule{
+								{
+									Field:  "customer_id",
+									Values: MatchValues{Eq: []string{"123", "456"}},
+									Weight: 50,
+								},
+								{
+									Field:  "customer_id",
+									Values: MatchValues{Eq: []string{"111"}},
+								},
 							},
-							{
-								Field:   "customer_id",
-								Include: []string{"111"},
-								Exclude: []string{"222"},
+							Disable: []DisableRule{
+								{
+									Field:  "customer_id",
+									Values: MatchValues{Eq: []string{"234", "567"}},
+								},
+								{
+									Field:  "customer_id",
+									Values: MatchValues{Eq: []string{"222"}},
+								},
 							},
 						},
 					},

--- a/config/example.yml
+++ b/config/example.yml
@@ -4,26 +4,34 @@ features:
 
   stripe_billing:
     rules:
-      - field: "customer_id"
-        weight: 50 # 50% chance that the feature will be enabled for the given customer_id
-        include: # explicitly include customer IDs 123 and 456
-          - "123"
-          - "456"
-        exclude: # explicitly exclude customers 234 and 567 (these override include rules)
-          - "234"
-          - "567"
-      - field: "customer_name"
-        include:
-          - "Alex" # enable the feature for any customer named 'Alex'
+      enable:
+        - field: "customer_id"
+          weight: 50 # 50% chance that the feature will be enabled for the given customer_id
+          values: # explicitly include customer IDs 123 and 456
+            eq:
+              - "123"
+              - "456"
+        - field: "customer_name"
+          values:
+            eq:
+              - "Alex" # enable the feature for any customer named 'Alex'
+      disable: # disable rules override enable rules
+        - field: "customer_id"
+          values: # explicitly disable customers 234 and 567
+            eq:
+              - "234"
+              - "567"
+
 
   profile_page_v2:
     rules:
-      # the following fields in the JSON request body will be combined and hashed:
-      - fields:
-          - "email"
-          - "customer_id"
+      enable:
+        # the following fields in the JSON request body will be combined and hashed:
+        - fields:
+            - "email"
+            - "customer_id"
 
-        # 10% chance that a customer with any given email/customer_id combination
-        # will have the feature enabled.
-        weight: 10
+          # 10% chance that a customer with any given email/customer_id combination
+          # will have the feature enabled.
+          weight: 10
 

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -18,10 +18,12 @@ var _ = Describe("service", func() {
 			Version: "1.0",
 			Features: map[string]cfg.Feature{
 				"profile_page_v2": {
-					Rules: []cfg.Rule{
-						{
-							Fields: []string{"email", "customer_id"},
-							Weight: 10,
+					Rules: cfg.Rules{
+						Enable: []cfg.EnableRule{
+							{
+								Fields: []string{"email", "customer_id"},
+								Weight: 10,
+							},
 						},
 					},
 				},
@@ -34,10 +36,14 @@ var _ = Describe("service", func() {
 			Version: "1.0",
 			Features: map[string]cfg.Feature{
 				"stripe_billing": {
-					Rules: []cfg.Rule{
-						{
-							Field:   "customer_id",
-							Include: []string{"123"},
+					Rules: cfg.Rules{
+						Enable: []cfg.EnableRule{
+							{
+								Field: "customer_id",
+								Values: cfg.MatchValues{
+									Eq: []string{"123"},
+								},
+							},
 						},
 					},
 				},
@@ -50,10 +56,14 @@ var _ = Describe("service", func() {
 			Version: "1.0",
 			Features: map[string]cfg.Feature{
 				"stripe_billing": {
-					Rules: []cfg.Rule{
-						{
-							Field:   "customer_id",
-							Exclude: []string{"321"},
+					Rules: cfg.Rules{
+						Disable: []cfg.DisableRule{
+							{
+								Field: "customer_id",
+								Values: cfg.MatchValues{
+									Eq: []string{"321"},
+								},
+							},
 						},
 					},
 				},
@@ -66,11 +76,22 @@ var _ = Describe("service", func() {
 			Version: "1.0",
 			Features: map[string]cfg.Feature{
 				"stripe_billing": {
-					Rules: []cfg.Rule{
-						{
-							Field:   "customer_id",
-							Include: []string{"123"},
-							Exclude: []string{"123"},
+					Rules: cfg.Rules{
+						Enable: []cfg.EnableRule{
+							{
+								Field: "customer_id",
+								Values: cfg.MatchValues{
+									Eq: []string{"123"},
+								},
+							},
+						},
+						Disable: []cfg.DisableRule{
+							{
+								Field: "customer_id",
+								Values: cfg.MatchValues{
+									Eq: []string{"123"},
+								},
+							},
 						},
 					},
 				},
@@ -83,10 +104,12 @@ var _ = Describe("service", func() {
 			Version: "1.0",
 			Features: map[string]cfg.Feature{
 				"stripe_billing": {
-					Rules: []cfg.Rule{
-						{
-							Field:  "customer_id",
-							Weight: 50,
+					Rules: cfg.Rules{
+						Enable: []cfg.EnableRule{
+							{
+								Field:  "customer_id",
+								Weight: 50,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Split enable/disable rules into separate groups. This better reflects
the way that the rules are processed, i.e. exclude rules are always
processed before include rules.

Introduces 'eq' matcher which checks for an exact string match. This
paves the way for different matchers.