### PR TITLE
Add set_var rules to set custom response vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ The service allows some configuration via environment variables:
 One of the features of the service is that it allows arbitrary fields in the "vars" parameter within the JSON body. You can use this to include information about the user such as their user ID or name. See config/example.yml for example YAML configurations, they have some annotations in there explaining what's going on}. Some example requests are below.
 
 ### Get the status of a feature
+
+Using custom variable 'customer_id':
+
 ```bash
 curl -XPOST localhost:3000/features/status/stripe_billing -d '{"vars":{"customer_id":"1"}}' | jq
 {
@@ -39,12 +42,31 @@ curl -XPOST localhost:3000/features/status/stripe_billing -d '{"vars":{"customer
   }
 }
 ```
+
+Using custom variable 'customer_name':
+
 ```bash
 curl -XPOST localhost:3000/features/status/stripe_billing -d '{"vars":{"customer_name":"Alex"}}' | jq
 {
   "features": {
     "stripe_billing": {
       "enabled": true
+    }
+  }
+}
+```
+
+Using custom variable 'customer_id' (showing custom vars in response):
+
+```bash
+curl -XPOST localhost:3000/features/status/stripe_billing -d '{"vars":{"customer_id":"123"}}' | jq
+{
+  "features": {
+    "stripe_billing": {
+      "enabled": true,
+      "vars": {
+        "foo": "bar"
+      }
     }
   }
 }

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -12,6 +12,7 @@ type Feature struct {
 type Rules struct {
 	Enable  []EnableRule  `yaml:"enable"`
 	Disable []DisableRule `yaml:"disable"`
+	SetVars []SetVarRule  `yaml:"set_vars"`
 }
 
 type EnableRule struct {
@@ -29,6 +30,16 @@ type DisableRule struct {
 	Values MatchValues `yaml:"values"`
 }
 
+type SetVarRule struct {
+	Field  string   `yaml:"field"`
+	Fields []string `yaml:"fields"`
+
+	Values MatchValues `yaml:"values"`
+	Weight int         `yaml:"weight"`
+
+	Set map[string]interface{} `json:"set"`
+}
+
 type MatchValues struct {
 	Eq []string `json:"eq"`
 }
@@ -44,6 +55,7 @@ func (c *Config) Append(a Config) {
 		if f, ok := c.Features[name]; ok {
 			f.Rules.Enable = append(f.Rules.Enable, a.Features[name].Rules.Enable...)
 			f.Rules.Disable = append(f.Rules.Disable, a.Features[name].Rules.Disable...)
+			f.Rules.SetVars = append(f.Rules.SetVars, a.Features[name].Rules.SetVars...)
 			c.Features[name] = f
 		} else {
 			c.Features[name] = feature

--- a/cfg/fixtures/dir/profile.yml
+++ b/cfg/fixtures/dir/profile.yml
@@ -9,4 +9,11 @@ features:
             - "email"
             - "customer_id"
           weight: 10
+      set_vars:
+        - fields:
+            - "customer_id"
+          weight: 50
+          set:
+            int_key: 1337
+            string_key: "my_string_value"
 

--- a/cfg/load_test.go
+++ b/cfg/load_test.go
@@ -22,6 +22,16 @@ var _ = Describe("cfg", func() {
 									Weight: 10,
 								},
 							},
+							SetVars: []SetVarRule{
+								{
+									Fields: []string{"customer_id"},
+									Weight: 50,
+									Set: map[string]interface{}{
+										"int_key":    1337,
+										"string_key": "my_string_value",
+									},
+								},
+							},
 						},
 					},
 					"stripe_billing": {

--- a/config/example.yml
+++ b/config/example.yml
@@ -21,6 +21,13 @@ features:
             eq:
               - "234"
               - "567"
+      set_vars: # set custom var 'foo' to value 'bar' if customer_id is '123'
+        - field: "customer_id"
+          values:
+            eq:
+              - "123"
+          set:
+            foo: bar
 
 
   profile_page_v2:

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -139,10 +140,12 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f h1:kDxGY2VmgABOe55qheT/TFqUMtcTHnomIPS1iv3G4Ms=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e h1:4nW4NLDYnU28ojHaHO8OVxFHk/aQ33U01a9cjED+pzE=
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/httpsvc/httpsvc_test.go
+++ b/httpsvc/httpsvc_test.go
@@ -27,8 +27,8 @@ var _ = Describe("httpsvc", func() {
 				FeaturesStatus(gomock.Any(), gomock.Any(), "").
 				Return(
 					spec.NewFeaturesResponse().
-						AddStatus("stripe_billing", true).
-						AddStatus("profile_page_v2", true),
+						AddStatus("stripe_billing", true, nil).
+						AddStatus("profile_page_v2", true, nil),
 					nil,
 				)
 
@@ -76,7 +76,7 @@ var _ = Describe("httpsvc", func() {
 				FeaturesStatus(gomock.Any(), gomock.Any(), "stripe_billing").
 				Return(
 					spec.NewFeaturesResponse().
-						AddStatus("stripe_billing", true),
+						AddStatus("stripe_billing", true, nil),
 					nil,
 				)
 

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -10,6 +10,8 @@ components:
       properties:
         enabled:
           type: boolean
+        vars:
+          type: object
     FeaturesRequest:
       properties:
         vars:

--- a/spec/types.gen.go
+++ b/spec/types.gen.go
@@ -5,7 +5,8 @@ package spec
 
 // FeatureStatus defines model for FeatureStatus.
 type FeatureStatus struct {
-	Enabled *bool `json:"enabled,omitempty"`
+	Enabled *bool                   `json:"enabled,omitempty"`
+	Vars    *map[string]interface{} `json:"vars,omitempty"`
 }
 
 // FeaturesRequest defines model for FeaturesRequest.

--- a/spec/types.go
+++ b/spec/types.go
@@ -1,17 +1,20 @@
 package spec
 
 func NewFeaturesResponse() *FeaturesResponse {
-	return &FeaturesResponse{}
+	return &FeaturesResponse{
+		Features: &map[string]FeatureStatus{},
+	}
 }
 
-func (r *FeaturesResponse) AddStatus(featureName string, enabled bool) *FeaturesResponse {
-	if r.Features == nil {
-		r.Features = &map[string]FeatureStatus{}
-	}
-
-	(*r.Features)[featureName] = FeatureStatus{
+func (r *FeaturesResponse) AddStatus(featureName string, enabled bool, vars map[string]interface{}) *FeaturesResponse {
+	s := FeatureStatus{
 		Enabled: &enabled,
 	}
 
+	if len(vars) > 0 {
+		s.Vars = &vars
+	}
+
+	(*r.Features)[featureName] = s
 	return r
 }


### PR DESCRIPTION
Allows configuration of special rules to set custom variables when the
rule criteria is met.